### PR TITLE
Update the weight type

### DIFF
--- a/src/chain_utils.py
+++ b/src/chain_utils.py
@@ -150,7 +150,7 @@ def send_token_multisig_wallet(substrate: SubstrateInterface, logger: logging.Lo
             'maybe_timepoint': None,
             'call': payload.value,
             'store_call': True,
-            'max_weight': 1000000000,
+            'max_weight': {'ref_time': 1000000000},
         })
 
     extrinsic = substrate.create_signed_extrinsic(

--- a/tool/utils.py
+++ b/tool/utils.py
@@ -115,7 +115,7 @@ def send_spent_token_from_multisig_wallet(
             'maybe_timepoint': None,
             'call': payload.value,
             'store_call': True,
-            'max_weight': 1000000000,
+            'max_weight': {'ref_time': 1000000000}
         })
 
     extrinsic = substrate.create_signed_extrinsic(
@@ -159,7 +159,7 @@ def send_refund_token_from_multisig_wallet(
             'maybe_timepoint': None,
             'call': payload.value,
             'store_call': True,
-            'max_weight': 1000000000,
+            'max_weight': {'ref_time': 1000000000}
         })
 
     extrinsic = substrate.create_signed_extrinsic(
@@ -192,7 +192,7 @@ def approve_token(substrate: SubstrateInterface, logger: logging.Logger, kp_sign
             'other_signatories': other_signatories,
             'maybe_timepoint': info['timepoint'],
             'call_hash': info['call_hash'],
-            'max_weight': 1000000000,
+            'max_weight': {'ref_time': 1000000000}
         })
 
     extrinsic = substrate.create_signed_extrinsic(


### PR DESCRIPTION
Upgrade to 0.9.29 because the weight type changes.

Note: Please don't merge until our node, 0.9.29, is deployed; otherwise, the charging process fails.